### PR TITLE
Wrapped `numberliteral` from FParsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,8 +798,8 @@ Keep in mind that many predefined parsers and some of the combinators have a var
 | `stringsSepBy1` | `Many1Strings(P<string>, P<String>)` |
 | `skipped` | `P<string> P<Unit>.WithSkipped()` |
 | `withSkippedString` | `P<T2> P<T1>.WithSkipped(Func<string, T1, T2>)`,<br>`P<(string,T)> P<T>.WithSkipped()` |
-| `numberLiteral` | not implemented |
-| `numberLiteralE` | not implemented |
+| `numberLiteral` | `P<NumberLiteral> NumberLiteral<U>(NumberLiteralOptions, string)` |
+| `numberLiteralE` | `P<NumberLiteral> NumberLiteralE<U>(NumberLiteralOptions, ErrorMessageList, CharStream<U>)` |
 | `pfloat` | `P<double> Float` |
 | `pint64` | `P<long> Long` |
 | `pint32` | `P<int> Int` |
@@ -841,5 +841,5 @@ This library is based on the following works:
 
 ## TODO
 
-* Wrap `numberLiteral` and `identifier` parsers?
+* Wrap `identifier` parsers?
 * Add [source link](https://github.com/dotnet/sourcelink) support?

--- a/README.md
+++ b/README.md
@@ -798,8 +798,8 @@ Keep in mind that many predefined parsers and some of the combinators have a var
 | `stringsSepBy1` | `Many1Strings(P<string>, P<String>)` |
 | `skipped` | `P<string> P<Unit>.WithSkipped()` |
 | `withSkippedString` | `P<T2> P<T1>.WithSkipped(Func<string, T1, T2>)`,<br>`P<(string,T)> P<T>.WithSkipped()` |
-| `numberLiteral` | `P<NumberLiteral> NumberLiteral<U>(NumberLiteralOptions, string)` |
-| `numberLiteralE` | `P<NumberLiteral> NumberLiteralE<U>(NumberLiteralOptions, ErrorMessageList, CharStream<U>)` |
+| `numberLiteral` | `P<NumberLiteral> NumberLiteral(NumberLiteralOptions, string)` |
+| `numberLiteralE` | `Reply<NumberLiteral> NumberLiteralE(NumberLiteralOptions, ErrorMessageList, CharStream<Unit>)` |
 | `pfloat` | `P<double> Float` |
 | `pint64` | `P<long> Long` |
 | `pint32` | `P<int> Int` |

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ var basicExprParser = new OPPBuilder<Unit, int, Unit>()
     .WithOperators(ops => ops
         .AddInfix("+", 1, (x, y) => x + y)
         .AddInfix("*", 2, (x, y) => x * y))
-    .WithTerms(Integer)
+    .WithTerms(Natural)
     .Build()
     .ExpressionParser;
 
@@ -416,7 +416,7 @@ var recursiveExprParser = new OPPBuilder<Unit, int, Unit>()
     .WithOperators(ops => ops
         .AddInfix("+", 1, (x, y) => x + y)
         .AddInfix("*", 2, (x, y) => x * y))
-    .WithTerms(term => Choice(Integer, Between('(', term, ')')))
+    .WithTerms(term => Choice(Natural, Between('(', term, ')')))
     .Build()
     .ExpressionParser;
 ```
@@ -436,7 +436,7 @@ var exprParser =
             .AddPostfix("!", 40, Factorial))
         .WithImplicitOperator(20, (x, y) => x * y)
         .WithTerms(term => Choice(
-            Integer.And(WS),
+            Natural.And(WS),
             Between(CharP('(').And(WS), term, CharP(')').And(WS))))
         .Build()
         .ExpressionParser);

--- a/src/FParsec.CSharp/CharParsersCS.cs
+++ b/src/FParsec.CSharp/CharParsersCS.cs
@@ -1424,8 +1424,8 @@ namespace FParsec.CSharp {
 
         /// <summary>
         /// <para>
-        /// `numberLiteralE` is an uncurried version of `numberLiteral` that can be used to implement number parsers
-        /// without having to construct a `numberLiteral` closure.
+        /// `NumberLiteralE()` is an uncurried version of `NumberLiteral()` that can be used to implement number parsers
+        /// without having to construct a `NumberLiteral()` closure.
         /// </para>
         /// </summary>
         public static Reply<NumberLiteral> NumberLiteralE(NumberLiteralOptions opt, ErrorMessageList errorInCaseNoLiteralFound, CharStream<Unit> stream) => numberLiteralE<Unit>(opt, errorInCaseNoLiteralFound, stream);

--- a/src/FParsec.CSharp/CharParsersCS.cs
+++ b/src/FParsec.CSharp/CharParsersCS.cs
@@ -1405,6 +1405,31 @@ namespace FParsec.CSharp {
         public static FSharpFunc<CharStream<U>, Reply<byte>> UByteU<U>() => puint8<U>();
 
         /// <summary>
+        /// <para>
+        /// Parses a number literal and returns the result in form of a `NumberLiteral` value.
+        /// </para>
+        /// <para>
+        /// The given `NumberLiteralOptions` argument determines the kind of number literals accepted.
+        /// The string `label` is used in the `Expected` error message that is generated when the parser fails without consuming input. 
+        /// </para>
+        /// <para>
+        /// The parser fails without consuming input, if not at least one digit (including the 0 in the format specifiers "0x" etc.) can be parsed.
+        /// It fails after consuming input, if no decimal digit comes after an exponent marker or no valid digit comes after a format specifier.
+        /// </para>
+        /// </summary>
+        public static FSharpFunc<CharStream<U>, Reply<NumberLiteral>> NumberLiteral<U>(NumberLiteralOptions opt, string label) => numberLiteral<U>(opt, label);
+
+        /// <summary>
+        /// <para>
+        /// `numberLiteralE` is an uncurried version of `numberLiteral` that can be used to implement number parsers
+        /// without having to construct a `numberLiteral` closure.
+        /// </para>
+        /// </summary>
+        public static Reply<NumberLiteral> NumberLiteralE<U>(NumberLiteralOptions opt,
+            ErrorMessageList errorInCaseNoLiteralFound, CharStream<U> stream) =>
+            numberLiteralE<U>(opt, errorInCaseNoLiteralFound, stream);
+
+        /// <summary>
         /// Returns a hexadecimal string representation of the `double`.
         /// </summary>
         public static string DoubleToHexString(double x) => floatToHexString(x);

--- a/src/FParsec.CSharp/CharParsersCS.cs
+++ b/src/FParsec.CSharp/CharParsersCS.cs
@@ -1425,9 +1425,7 @@ namespace FParsec.CSharp {
         /// without having to construct a `numberLiteral` closure.
         /// </para>
         /// </summary>
-        public static Reply<NumberLiteral> NumberLiteralE<U>(NumberLiteralOptions opt,
-            ErrorMessageList errorInCaseNoLiteralFound, CharStream<U> stream) =>
-            numberLiteralE<U>(opt, errorInCaseNoLiteralFound, stream);
+        public static Reply<NumberLiteral> NumberLiteralE<U>(NumberLiteralOptions opt, ErrorMessageList errorInCaseNoLiteralFound, CharStream<U> stream) => numberLiteralE<U>(opt, errorInCaseNoLiteralFound, stream);
 
         /// <summary>
         /// Returns a hexadecimal string representation of the `double`.

--- a/src/FParsec.CSharp/CharParsersCS.cs
+++ b/src/FParsec.CSharp/CharParsersCS.cs
@@ -1417,7 +1417,10 @@ namespace FParsec.CSharp {
         /// It fails after consuming input, if no decimal digit comes after an exponent marker or no valid digit comes after a format specifier.
         /// </para>
         /// </summary>
-        public static FSharpFunc<CharStream<U>, Reply<NumberLiteral>> NumberLiteral<U>(NumberLiteralOptions opt, string label) => numberLiteral<U>(opt, label);
+        public static FSharpFunc<CharStream<Unit>, Reply<NumberLiteral>> NumberLiteral(NumberLiteralOptions opt, string label) => numberLiteral<Unit>(opt, label);
+        
+        /// <summary>`NumberLiteralU()` behaves like `NumberLiteral`, but supports user state.</summary>
+        public static FSharpFunc<CharStream<U>, Reply<NumberLiteral>> NumberLiteralU<U>(NumberLiteralOptions opt, string label) => numberLiteral<U>(opt, label);
 
         /// <summary>
         /// <para>
@@ -1425,7 +1428,10 @@ namespace FParsec.CSharp {
         /// without having to construct a `numberLiteral` closure.
         /// </para>
         /// </summary>
-        public static Reply<NumberLiteral> NumberLiteralE<U>(NumberLiteralOptions opt, ErrorMessageList errorInCaseNoLiteralFound, CharStream<U> stream) => numberLiteralE<U>(opt, errorInCaseNoLiteralFound, stream);
+        public static Reply<NumberLiteral> NumberLiteralE(NumberLiteralOptions opt, ErrorMessageList errorInCaseNoLiteralFound, CharStream<Unit> stream) => numberLiteralE<Unit>(opt, errorInCaseNoLiteralFound, stream);
+        
+        /// <summary>`NumberLiteralEU()` behaves like `NumberLiteralE`, but supports user state.</summary>
+        public static Reply<NumberLiteral> NumberLiteralEU<U>(NumberLiteralOptions opt, ErrorMessageList errorInCaseNoLiteralFound, CharStream<U> stream) => numberLiteralE<U>(opt, errorInCaseNoLiteralFound, stream);
 
         /// <summary>
         /// Returns a hexadecimal string representation of the `double`.

--- a/src/Tests/BasicExamples.cs
+++ b/src/Tests/BasicExamples.cs
@@ -112,7 +112,7 @@ namespace Tests {
         [Fact]
         public void ParseNumberLiteralE() {
             const string numberString = "-13.45e+2";
-            var errorInCaseNoLiteralFound = new ErrorMessageList(new ErrorMessage.Unexpected(""));
+            var errorInCaseNoLiteralFound = new ErrorMessageList(new ErrorMessage.Unexpected("unexpected message"));
             var charStream = new CharStream<Unit>(numberString, 0, numberString.Length);
             var (status, result, errorMessageList) = NumberLiteralE(
                 NumberLiteralOptions.AllowMinusSign |

--- a/src/Tests/BasicExamples.cs
+++ b/src/Tests/BasicExamples.cs
@@ -93,6 +93,41 @@ namespace Tests {
 
         [Fact] public void ParseFloat() => Float.ParseString("13.45").ShouldBe(13.45);
 
+        [Fact]
+        public void ParseNumberLiteral() {
+            var (status, result, errorMessageList) = NumberLiteral(
+                NumberLiteralOptions.AllowMinusSign |
+                NumberLiteralOptions.AllowFraction |
+                NumberLiteralOptions.AllowExponent, "scientific notation").ParseString("-13.45e+2");
+            
+            status.ShouldBe(ReplyStatus.Ok);
+            result.Info.ShouldBe(NumberLiteralResultFlags.HasMinusSign |
+                                                  NumberLiteralResultFlags.HasIntegerPart |
+                                                  NumberLiteralResultFlags.HasFraction |
+                                                  NumberLiteralResultFlags.HasExponent |
+                                                  NumberLiteralResultFlags.IsDecimal);
+            errorMessageList.ShouldBeNull();
+        }
+        
+        [Fact]
+        public void ParseNumberLiteralE() {
+            const string numberString = "-13.45e+2";
+            var errorInCaseNoLiteralFound = new ErrorMessageList(new ErrorMessage.Unexpected(""));
+            var charStream = new CharStream<Unit>(numberString, 0, numberString.Length);
+            var (status, result, errorMessageList) = NumberLiteralE(
+                NumberLiteralOptions.AllowMinusSign |
+                NumberLiteralOptions.AllowFraction |
+                NumberLiteralOptions.AllowExponent, errorInCaseNoLiteralFound, charStream);
+            
+            status.ShouldBe(ReplyStatus.Ok);
+            result.Info.ShouldBe(NumberLiteralResultFlags.HasMinusSign |
+                                 NumberLiteralResultFlags.HasIntegerPart |
+                                 NumberLiteralResultFlags.HasFraction |
+                                 NumberLiteralResultFlags.HasExponent |
+                                 NumberLiteralResultFlags.IsDecimal);
+            errorMessageList.ShouldBeNull();
+        }
+
         #endregion Numbers
 
         #region White space


### PR DESCRIPTION
`numberliteral` provide a lot of flexibility thanks to the `NumberLiteralOptions` enum, so I thought we should definitely bring it over. 

My attempt at trying to contribute :)